### PR TITLE
HACK: Allow Elite/Tec9 on hzCrosshair_recoil

### DIFF
--- a/src/core/sndFetch/weapon/Elite.cfg
+++ b/src/core/sndFetch/weapon/Elite.cfg
@@ -3,4 +3,6 @@ echo [Weapon] Elite
 rapidfire_set8
 +rapidfire
 
+hzCrosshair_recoil_checkwp_pass
+
 alias hzSndFetch_curwp exec Horizon/src/core/sndFetch/weapon/Elite

--- a/src/core/sndFetch/weapon/Tec9.cfg
+++ b/src/core/sndFetch/weapon/Tec9.cfg
@@ -3,4 +3,6 @@ echo [Weapon] Tec9
 rapidfire_set8
 +rapidfire
 
+hzCrosshair_recoil_checkwp_pass
+
 alias hzSndFetch_curwp exec Horizon/src/core/sndFetch/weapon/Tec9


### PR DESCRIPTION
- TODO: Only enable hzCrosshair_recoil for pistols while rapidfire_enable